### PR TITLE
Add configure artifacts to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ autom4te.cache
 config.log
 config.status
 configure
+configure~
 dist-install
 ghc.mk
 terminfo.buildinfo


### PR DESCRIPTION
A very little change. Cosmetic.

[ghc.nix](https://gitlab.haskell.org/ghc/ghc.nix) leaves `configure~` which is registered as a useless change.
Default `MSYS2` configure tools do same.

It makes your local copy look `dirty`:

```diff
diff --git a/libraries/terminfo b/libraries/terminfo
--- a/libraries/terminfo
+++ b/libraries/terminfo
@@ -1 +1 @@
-Subproject commit a76fac0c60cf6db7ed724d9b5c5067d77a23efc7
+Subproject commit a76fac0c60cf6db7ed724d9b5c5067d77a23efc7-dirty
```